### PR TITLE
Replace body1 by bodyTex2

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ class FlashChat extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData.dark().copyWith(
         textTheme: TextTheme(
-          body1: TextStyle(color: Colors.black54),
+          bodyText2: TextStyle(color: Colors.black54),
         ),
       ),
       home: WelcomeScreen(),


### PR DESCRIPTION
According Flutter guidelines:
"'body1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is bodyText2"

Source: https://api.flutter.dev/flutter/material/TextTheme/body1.html