### PR TITLE
'body1' property deprecated

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ class FlashChat extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData.dark().copyWith(
         textTheme: TextTheme(
-          body1: TextStyle(color: Colors.black54),
+          bodyText2: TextStyle(color: Colors.black54),
         ),
       ),
       home: WelcomeScreen(),


### PR DESCRIPTION
Replace 'body1' with 'bodyText2' as stated in API documentation:
https://docs.flutter.dev/release/breaking-changes/2-2-deprecations